### PR TITLE
feat: Intentionally break Dockerfile for testing PR failure

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # 使用官方 Python Runtime 作為基礎映像
 FROM python:3.10-slim
 
+#simulate a bug
+THISWILLBREAKEDOCKERFILE
+
 # 設定工作目錄
 WORKDIR /app
 


### PR DESCRIPTION
This PR intentionally breaks the Dockerfile to test GitHub Action failure detection during a PR build.

How the Dockerfile was broken:
- Added a line `THISWILLBREAKEDOCKERFILE` which causes the build to fail.